### PR TITLE
Added Support for Int64 in filter

### DIFF
--- a/src/lucky_search/query.cr
+++ b/src/lucky_search/query.cr
@@ -1,7 +1,7 @@
 module LuckySearch
   class Query
     alias Sort = Hash(String, NamedTuple(order: Symbol)) | String | Hash(String, String)
-    alias FilterValue = Array(Int32) | Array(Float32) | Array(Bool) | Array(String) | Nil
+    alias FilterValue = Array(Int32) | Array(Int64) | Array(Float32) | Array(Bool) | Array(String) | Nil
     alias Filter = Hash(String, FilterValue)
 
     getter search : String
@@ -283,7 +283,7 @@ module LuckySearch
       end
     end
 
-    alias FilterTerm = Hash(String, (Int32 | Float32 | Bool | String))
+    alias FilterTerm = Hash(String, (Int32 | Int64 | Float32 | Bool | String))
 
     protected def missing_term_filter(key)
       sub = Subfilter.new

--- a/src/lucky_search/record_indexer.cr
+++ b/src/lucky_search/record_indexer.cr
@@ -2,6 +2,7 @@ require "uuid"
 require "avram"
 
 class LuckySearch::RecordIndexer
+  Log = Log.for(self)
   getter document_name : String
   getter id : Int64 | UUID
 


### PR DESCRIPTION
Added support for Int64 in advanced query filter as many ids in models are in Int64 in Lucky and would be nice to filter on those without changing them to Int32 and maybe break something.